### PR TITLE
Fixed Facebook custom link.

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -63,13 +63,19 @@ function setting_github() { ?>
 			<input type="text" name="github" id="github" value="<?php echo get_option('github'); ?>" />
 			<?php }
 
+function setting_facebook() { ?>
+			<input type="text" name="facebook" id="facebook" value="<?php echo get_option('facebook'); ?>" />
+			<?php }
+
 function custom_settings_page_setup() {
   add_settings_section('section', 'All Settings', null, 'theme-options');
   add_settings_field('twitter', 'Twitter URL', 'setting_twitter', 'theme-options', 'section');
   add_settings_field('github', 'GitHub URL', 'setting_github', 'theme-options', 'section');
+  add_settings_field('facebook', 'Facebook URL', 'setting_facebook', 'theme-options', 'section');
   
 	register_setting('section', 'twitter');
   register_setting('section', 'github');
+  register_setting('section', 'facebook');
 }
 add_action( 'admin_init', 'custom_settings_page_setup' );
 

--- a/sidebar.php
+++ b/sidebar.php
@@ -14,7 +14,7 @@
 		<ol class="list-unstyled">
 			<li><a href="<?php echo get_option('github'); ?>">GitHub</a></li>
 			<li><a href="<?php echo get_option('twitter'); ?>">Twitter</a></li>
-			<li><a href="#">Facebook</a></li>
+			<li><a href="<?php echo get_option('facebook'); ?>">Facebook</a></li>
 		</ol>
 	</div>
 </div><!-- /.blog-sidebar -->


### PR DESCRIPTION
I noticed that the Facebook custom link was statically set to #, I added a custom variable similar to the GitHub and Twitter links.
